### PR TITLE
fix(wolframalpha): the result of session.app.http.get<string> may not be a string

### DIFF
--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -35,7 +35,7 @@ async function showFull(session: Session, input: string, appid: string) {
 }
 
 async function showShort(session: Session, input: string, appid: string) {
-  return session.app.http.get<string>('http://api.wolframalpha.com/v1/result', { input, appid })
+  return String(await session.app.http.get('http://api.wolframalpha.com/v1/result', { input, appid }))
 }
 
 export const name = 'alpha'


### PR DESCRIPTION
看上去 axios 会自动转换类型，所以拿到的结果并不一定是 string，即使加了个 `<string>` 让他看上去是一个 string （